### PR TITLE
Add support for hexadecimal inputs / outputs

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,42 +8,50 @@ use std::num::{ParseIntError, ParseFloatError};
 #[derive(Debug, PartialEq)]
 pub enum PartialComp {
     Unary { op: String, arg: String },
-    Binary { op: String, lhs: String, rhs: String }
+    Binary {
+        op: String,
+        lhs: String,
+        rhs: String,
+    },
 }
 
 impl PartialComp {
-
-    pub fn unary<T, U>(op: T, arg: U) -> Self 
-        where T: ToString, U: ToString
+    pub fn unary<T, U>(op: T, arg: U) -> Self
+        where T: ToString,
+              U: ToString
     {
-        PartialComp::Unary {op: op.to_string(), arg: arg.to_string()}
-    }
-
-    pub fn binary<T, U, V>(op: T, lhs: U, rhs: V) -> Self 
-        where T: ToString, U: ToString, V: ToString
-    {
-        PartialComp::Binary { 
-            op: op.to_string(), 
-            lhs: lhs.to_string(), 
-            rhs: rhs.to_string() 
+        PartialComp::Unary {
+            op: op.to_string(),
+            arg: arg.to_string(),
         }
     }
 
+    pub fn binary<T, U, V>(op: T, lhs: U, rhs: V) -> Self
+        where T: ToString,
+              U: ToString,
+              V: ToString
+    {
+        PartialComp::Binary {
+            op: op.to_string(),
+            lhs: lhs.to_string(),
+            rhs: rhs.to_string(),
+        }
+    }
 }
 
 impl fmt::Display for PartialComp {
-
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             PartialComp::Unary { ref op, ref arg } => {
                 write!(f, "{} {}", op, arg)
             }
-            PartialComp::Binary { ref op, ref lhs, ref rhs } => {
-                write!(f, "{} {} {}", lhs, op, rhs)
-            }
+            PartialComp::Binary {
+                ref op,
+                ref lhs,
+                ref rhs,
+            } => write!(f, "{} {} {}", lhs, op, rhs),
         }
     }
-
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,8 +3,48 @@ use std::error::Error;
 
 use std::num::{ParseIntError, ParseFloatError};
 
+/// Represents a partial computation that can be captured as part of an
+/// error message.
+#[derive(Debug, PartialEq)]
+pub enum PartialComp {
+    Unary { op: String, arg: String },
+    Binary { op: String, lhs: String, rhs: String }
+}
+
+impl PartialComp {
+
+    pub fn unary<T>(op: T, arg: T) -> Self 
+        where T: Into<String>
+    {
+        PartialComp::Unary {op: op.into(), arg: arg.into()}
+    }
+
+    pub fn binary<T>(op: T, lhs: T, rhs: T) -> Self 
+        where T: Into String
+    {
+        PartialComp::Binary { op: op.into(), lhs: lhs.into(), rhs: rhs.into() }
+    }
+
+}
+
+impl fmt::Display {
+
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Unary { op, arg } => {
+                write!(f, "{} {}", op, arg),
+            }
+            Binary { op, lhs, rhs } => {
+                write!(f, "{} {} {}", lhs, arg, rhs)
+            }
+        }
+    }
+
+}
+
 #[derive(Debug, PartialEq)]
 pub enum CalcError {
+    BadTypes(PartialComp),
     DivideByZero,
     InvalidNumber(String),
     InvalidOperator(char),
@@ -13,6 +53,8 @@ pub enum CalcError {
     UnknownAtom(String),
     UnexpectedEndOfInput,
     UnmatchedParenthesis,
+    WouldOverflow(PartialComp),
+    WouldTruncate(PartialComp),
     NoFunctionArgument,
 }
 
@@ -21,6 +63,9 @@ use CalcError::*;
 impl fmt::Display for CalcError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            BadTypes(ref comp) => {
+                write!(f, "expression '{}' is not well typed", comp)
+            }
             DivideByZero => write!(f, "attempted to divide by zero"),
             InvalidNumber(ref number) => {
                 write!(f, "invalid number: {}", number)
@@ -34,6 +79,12 @@ impl fmt::Display for CalcError {
             }
             UnknownAtom(ref atom) => {
                 write!(f, "unknown variable or function '{}'", atom)
+            }
+            WouldOverflow(ref comp) => {
+                write!(f, "expression '{}' would overflow", comp)
+            }
+            WouldTruncate(ref comp) => {
+                write!(f, "expression '{}' would be truncated", comp)
             }
             UnexpectedEndOfInput => write!(f, "unexpected end of input"),
             UnmatchedParenthesis => write!(f, "unmatched patenthesis"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,7 +67,6 @@ pub enum CalcError {
     UnmatchedParenthesis,
     WouldOverflow(PartialComp),
     WouldTruncate(PartialComp),
-    NoFunctionArgument,
 }
 
 use CalcError::*;
@@ -100,7 +99,6 @@ impl fmt::Display for CalcError {
             }
             UnexpectedEndOfInput => write!(f, "unexpected end of input"),
             UnmatchedParenthesis => write!(f, "unmatched patenthesis"),
-            NoFunctionArgument => write!(f, "no bracketed function argument"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,29 +13,33 @@ pub enum PartialComp {
 
 impl PartialComp {
 
-    pub fn unary<T>(op: T, arg: T) -> Self 
-        where T: Into<String>
+    pub fn unary<T, U>(op: T, arg: U) -> Self 
+        where T: ToString, U: ToString
     {
-        PartialComp::Unary {op: op.into(), arg: arg.into()}
+        PartialComp::Unary {op: op.to_string(), arg: arg.to_string()}
     }
 
-    pub fn binary<T>(op: T, lhs: T, rhs: T) -> Self 
-        where T: Into String
+    pub fn binary<T, U, V>(op: T, lhs: U, rhs: V) -> Self 
+        where T: ToString, U: ToString, V: ToString
     {
-        PartialComp::Binary { op: op.into(), lhs: lhs.into(), rhs: rhs.into() }
+        PartialComp::Binary { 
+            op: op.to_string(), 
+            lhs: lhs.to_string(), 
+            rhs: rhs.to_string() 
+        }
     }
 
 }
 
-impl fmt::Display {
+impl fmt::Display for PartialComp {
 
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Unary { op, arg } => {
-                write!(f, "{} {}", op, arg),
+            PartialComp::Unary { ref op, ref arg } => {
+                write!(f, "{} {}", op, arg)
             }
-            Binary { op, lhs, rhs } => {
-                write!(f, "{} {} {}", lhs, arg, rhs)
+            PartialComp::Binary { ref op, ref lhs, ref rhs } => {
+                write!(f, "{} {} {}", lhs, op, rhs)
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::error::Error;
 
-use std::num::ParseFloatError;
+use std::num::{ParseIntError, ParseFloatError};
 
 #[derive(Debug, PartialEq)]
 pub enum CalcError {
@@ -44,6 +44,12 @@ impl fmt::Display for CalcError {
 
 impl From<ParseFloatError> for CalcError {
     fn from(data: ParseFloatError) -> CalcError {
+        CalcError::InvalidNumber(data.description().into())
+    }
+}
+
+impl From<ParseIntError> for CalcError {
+    fn from(data: ParseIntError) -> CalcError {
         CalcError::InvalidNumber(data.description().into())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod bench;
 mod error;
 mod token;
 mod parse;
+mod value;
 
 pub use error::CalcError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ mod tests {
             ("3 << (4 >> 2)", Value::Dec(6)),
             ("~0", Value::Dec(-1)),
             ("cos pi + sin (tau * (3 / 4))", Value::Float(-2.0)),
+            ("~~5", Value::Dec(5)),
         ];
         for (input, expected) in cases {
             assert_eq!(eval(input), Ok(expected));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,14 +32,14 @@ mod tests {
     #[test]
     fn basics() {
         let cases = vec![
-            ("  1 +   1", Value::Float(2.0)),
-            (" 4 * 7 - 14", Value::Float(14.0)),
-            (" 2 << 16 ", Value::Float(131072.0)),
+            ("  1 +   1", Value::Dec(2)),
+            (" 4 * 7 - 14", Value::Dec(14)),
+            (" 2 << 16 ", Value::Dec(131072)),
             (" ((4 * 18) % 17) / 3", Value::Float(4.0 / 3.0)),
-            ("2²³²", Value::Float(4096.0)),
-            ("4 ^ 3 ^ 2 ^ 3 ^ 4 ^ 2", Value::Float(0.0)),
-            ("3 << (4 >> 2)", Value::Float(6.0)),
-            ("~0", Value::Float(-1.0)),
+            ("2²³²", Value::Dec(4096)),
+            ("4 ^ 3 ^ 2 ^ 3 ^ 4 ^ 2", Value::Dec(0)),
+            ("3 << (4 >> 2)", Value::Dec(6)),
+            ("~0", Value::Dec(-1)),
             ("cos pi + sin (tau * (3 / 4))", Value::Float(-2.0)),
         ];
         for (input, expected) in cases {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,14 +11,15 @@ mod token;
 mod parse;
 mod value;
 
+pub use value::Value;
 pub use error::CalcError;
 
-pub fn eval(input: &str) -> Result<f64, CalcError> {
+pub fn eval(input: &str) -> Result<Value, CalcError> {
     let mut env = parse::DefaultEnvironment;
     token::tokenize(input).and_then(|x| parse::parse(&x, &mut env))
 }
 
-pub fn eval_with_env<E>(input: &str, env: &mut E) -> Result<f64, CalcError>
+pub fn eval_with_env<E>(input: &str, env: &mut E) -> Result<Value, CalcError>
     where E: parse::Environment
 {
     token::tokenize(input).and_then(|x| parse::parse(&x, env))
@@ -31,15 +32,15 @@ mod tests {
     #[test]
     fn basics() {
         let cases = vec![
-            ("  1 +   1", 2.0),
-            (" 4 * 7 - 14", 14.0),
-            (" 2 << 16 ", 131072.0),
-            (" ((4 * 18) % 17) / 3", 4.0 / 3.0),
-            ("2²³²", 4096.0),
-            ("4 ^ 3 ^ 2 ^ 3 ^ 4 ^ 2", 0.0),
-            ("3 << (4 >> 2)", 6.0),
-            ("~0", -1.0),
-            ("cos pi + sin (tau * (3 / 4))", -2.0),
+            ("  1 +   1", Value::Float(2.0)),
+            (" 4 * 7 - 14", Value::Float(14.0)),
+            (" 2 << 16 ", Value::Float(131072.0)),
+            (" ((4 * 18) % 17) / 3", Value::Float(4.0 / 3.0)),
+            ("2²³²", Value::Float(4096.0)),
+            ("4 ^ 3 ^ 2 ^ 3 ^ 4 ^ 2", Value::Float(0.0)),
+            ("3 << (4 >> 2)", Value::Float(6.0)),
+            ("~0", Value::Float(-1.0)),
+            ("cos pi + sin (tau * (3 / 4))", Value::Float(-2.0)),
         ];
         for (input, expected) in cases {
             assert_eq!(eval(input), Ok(expected));
@@ -49,18 +50,22 @@ mod tests {
 
     #[test]
     fn random() {
-        let cases = vec![
-            (
-                "((15 * 10) - 26 * 19 - 30 / ((57 * 79 + 93 / 87 / 47))) / 8",
-                -43.00083277394169075309
-            ),
-            ("(3 << 6) * 7 + (40 / 3)", 1357.33333333333333333333),
-            ("(21 & (5) ^ (20 & 81)) / (25 << 3)", 0.105),
-            (
-                "(79 & 14) * ((3) - 76 + 67 / (62) - (85 ^ (7 - (32) >> 52)))",
-                197.12903225806448
-            ),
-        ];
+        let cases =
+            vec![
+                (
+                    "((15 * 10) - 26 * 19 - 30 / ((57 * 79 + 93 / 87 / 47))) / 8",
+                    Value::Float(-43.00083277394169075309)
+                ),
+                (
+                    "(3 << 6) * 7 + (40 / 3)",
+                    Value::Float(1357.33333333333333333333)
+                ),
+                ("(21 & (5) ^ (20 & 81)) / (25 << 3)", Value::Float(0.105)),
+                (
+                    "(79 & 14) * ((3) - 76 + 67 / (62) - (85 ^ (7 - (32) >> 52)))",
+                    Value::Float(197.12903225806448)
+                ),
+            ];
 
         for (input, expected) in cases {
             assert_eq!(eval(input), Ok(expected));

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -13,7 +13,11 @@ pub trait Environment {
     /// Resolve an atom given the name of the atom and some number of
     /// arguments
     /// Precondition: `args.len() == self.arity(atom)`
-    fn resolve(&mut self, atom: &str, args: &[IR]) -> Result<Value, CalcError>;
+    fn resolve(
+        &mut self,
+        atom: &str,
+        args: &[Value],
+    ) -> Result<Value, CalcError>;
 }
 
 
@@ -173,7 +177,7 @@ fn g_expr<E>(token_list: &[Token], env: &mut E) -> Result<IR, CalcError>
                     for _ in 0..nargs {
                         let ir = g_expr(&token_list[start..], env)?;
                         start += ir.tokens;
-                        args.push(ir);
+                        args.push(ir.value());
                     }
                     let res = env.resolve(s, &args);
                     Ok(IR::new(res?, start))
@@ -225,14 +229,18 @@ impl Environment for DefaultEnvironment {
         }
     }
 
-    fn resolve(&mut self, atom: &str, args: &[IR]) -> Result<Value, CalcError> {
+    fn resolve(
+        &mut self,
+        atom: &str,
+        args: &[Value],
+    ) -> Result<Value, CalcError> {
         match atom {
             "pi" => Ok(Value::Float(::std::f64::consts::PI)),
             "tau" => Ok(Value::Float(::std::f64::consts::PI * 2.0)),
-            "log" => Ok(Value::Float(args[0].value().as_float().log(10.0))),
-            "sin" => Ok(Value::Float(args[0].value().as_float().sin())),
-            "cos" => Ok(Value::Float(args[0].value().as_float().cos())),
-            "tan" => Ok(Value::Float(args[0].value().as_float().tan())),
+            "log" => Ok(Value::Float(args[0].as_float().log(10.0))),
+            "sin" => Ok(Value::Float(args[0].as_float().sin())),
+            "cos" => Ok(Value::Float(args[0].as_float().cos())),
+            "tan" => Ok(Value::Float(args[0].as_float().tan())),
             _ => Err(CalcError::UnknownAtom(atom.to_owned())),
         }
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,6 +1,6 @@
 use token::*;
 use error::CalcError;
-use value::{Value, IR, IntermediateResult};
+use value::{Value, IR};
 
 /// Represents an environment for evaluating a mathematical expression
 pub trait Environment {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,25 +1,6 @@
 use token::*;
 use error::CalcError;
-
-
-#[derive(Clone, Debug)]
-pub struct IntermediateResult {
-    value: f64,
-    tokens_read: usize,
-}
-
-impl IntermediateResult {
-    pub fn new(value: f64, tokens_read: usize) -> Self {
-        IntermediateResult { value, tokens_read }
-    }
-
-    /// Determines if the underlying value can be represented as an integer.
-    /// This is used for typechecking of sorts: we can only do bitwise
-    /// operations on integers.
-    pub fn is_whole(&self) -> bool {
-        self.value == self.value.floor()
-    }
-}
+use value::{Value, IR, IntermediateResult};
 
 /// Represents an environment for evaluating a mathematical expression
 pub trait Environment {
@@ -32,121 +13,44 @@ pub trait Environment {
     /// Resolve an atom given the name of the atom and some number of
     /// arguments
     /// Precondition: `args.len() == self.arity(atom)`
-    fn resolve(
-        &mut self,
-        atom: &str,
-        args: &[IntermediateResult],
-    ) -> Result<f64, CalcError>;
+    fn resolve(&mut self, atom: &str, args: &[IR]) -> Result<Value, CalcError>;
 }
 
 
-fn d_expr<E>(
-    token_list: &[Token],
-    env: &mut E,
-) -> Result<IntermediateResult, CalcError>
+fn d_expr<E>(token_list: &[Token], env: &mut E) -> Result<IR, CalcError>
     where E: Environment
 {
 
     if !token_list.is_empty() && token_list[0] == Token::BitWiseNot {
-        let mut e = e_expr(&token_list[1..], env)?;
-        if e.is_whole() {
-            let mut int_f = e.value.floor() as i64;
-            int_f = !(int_f);
-            e.value = int_f as f64;
-            e.tokens_read += 1;
-            return Ok(e);
-        } else {
-            return Err(CalcError::UnexpectedToken(
-                e.value.to_string(),
-                "Not an integer number!",
-            ));
-        }
+        let mut e = (!(e_expr(&token_list[1..], env)?))?;
+        e.tokens += 1;
+        return Ok(e);
     }
 
     let mut e1 = e_expr(token_list, env)?;
-    let mut index = e1.tokens_read;
+    let mut index = e1.tokens;
 
     while index < token_list.len() {
         match token_list[index] {
             Token::BitWiseAnd => {
-                let e2 = e_expr(&token_list[index + 1..], env)?;
-                if e1.is_whole() && e2.is_whole() {
-                    let mut int_f = e1.value.floor() as i64;
-                    let int_s = e2.value.floor() as i64;
-                    int_f &= int_s;
-                    e1.value = int_f as f64;
-                    e1.tokens_read += e2.tokens_read + 1;
-                } else {
-                    return Err(CalcError::UnexpectedToken(
-                        (if e1.is_whole() { e2.value } else { e1.value })
-                            .to_string(),
-                        "Not an integer number!",
-                    ));
-                }
+                e1 = (e1 & e_expr(&token_list[index + 1..], env)?)?;
+                e1.tokens += 1;
             }
             Token::BitWiseOr => {
-                let e2 = e_expr(&token_list[index + 1..], env)?;
-                if e1.is_whole() && e2.is_whole() {
-                    let mut int_f = e1.value.floor() as i64;
-                    let int_s = e2.value.floor() as i64;
-                    int_f |= int_s;
-                    e1.value = int_f as f64;
-                    e1.tokens_read += e2.tokens_read + 1;
-                } else {
-                    return Err(CalcError::UnexpectedToken(
-                        (if e1.is_whole() { e2.value } else { e1.value })
-                            .to_string(),
-                        "Not an integer number!",
-                    ));
-                }
+                e1 = (e1 | e_expr(&token_list[index + 1..], env)?)?;
+                e1.tokens += 1;
             }
             Token::BitWiseXor => {
-                let e2 = e_expr(&token_list[index + 1..], env)?;
-                if e1.is_whole() && e2.is_whole() {
-                    let mut int_f = e1.value.floor() as i64;
-                    let int_s = e2.value.floor() as i64;
-                    int_f ^= int_s;
-                    e1.value = int_f as f64;
-                    e1.tokens_read += e2.tokens_read + 1;
-                } else {
-                    return Err(CalcError::UnexpectedToken(
-                        (if e1.is_whole() { e2.value } else { e1.value })
-                            .to_string(),
-                        "Not an integer number!",
-                    ));
-                }
+                e1 = (e1 ^ e_expr(&token_list[index + 1..], env)?)?;
+                e1.tokens += 1;
             }
             Token::BitWiseLShift => {
-                let e2 = e_expr(&token_list[index + 1..], env)?;
-                if e1.is_whole() && e2.is_whole() {
-                    let mut int_f = e1.value.floor() as i64;
-                    let int_s = e2.value.floor() as i64;
-                    int_f <<= int_s;
-                    e1.value = int_f as f64;
-                    e1.tokens_read += e2.tokens_read + 1;
-                } else {
-                    return Err(CalcError::UnexpectedToken(
-                        (if e1.is_whole() { e2.value } else { e1.value })
-                            .to_string(),
-                        "Not an integer number!",
-                    ));
-                }
+                e1 = (e1 << e_expr(&token_list[index + 1..], env)?)?;
+                e1.tokens += 1;
             }
             Token::BitWiseRShift => {
-                let e2 = e_expr(&token_list[index + 1..], env)?;
-                if e1.is_whole() && e2.is_whole() {
-                    let mut int_f = e1.value.floor() as i64;
-                    let int_s = e2.value.floor() as i64;
-                    int_f >>= int_s;
-                    e1.value = int_f as f64;
-                    e1.tokens_read += e2.tokens_read + 1;
-                } else {
-                    return Err(CalcError::UnexpectedToken(
-                        (if e1.is_whole() { e2.value } else { e1.value })
-                            .to_string(),
-                        "Not an integer number!",
-                    ));
-                }
+                e1 = (e1 >> e_expr(&token_list[index + 1..], env)?)?;
+                e1.tokens += 1;
             }
             Token::Number(ref n) => {
                 return Err(
@@ -155,31 +59,26 @@ fn d_expr<E>(
             }
             _ => break,
         };
-        index = e1.tokens_read;
+        index = e1.tokens;
     }
     Ok(e1)
 }
 // Addition and subtraction
-fn e_expr<E>(
-    token_list: &[Token],
-    env: &mut E,
-) -> Result<IntermediateResult, CalcError>
+fn e_expr<E>(token_list: &[Token], env: &mut E) -> Result<IR, CalcError>
     where E: Environment
 {
     let mut t1 = t_expr(token_list, env)?;
-    let mut index = t1.tokens_read;
+    let mut index = t1.tokens;
 
     while index < token_list.len() {
         match token_list[index] {
             Token::Plus => {
-                let t2 = t_expr(&token_list[index + 1..], env)?;
-                t1.value += t2.value;
-                t1.tokens_read += t2.tokens_read + 1;
+                t1 = t1 + t_expr(&token_list[index + 1..], env)?;
+                t1.tokens += 1;
             }
             Token::Minus => {
-                let t2 = t_expr(&token_list[index + 1..], env)?;
-                t1.value -= t2.value;
-                t1.tokens_read += t2.tokens_read + 1;
+                t1 = t1 - t_expr(&token_list[index + 1..], env)?;
+                t1.tokens += 1;
             }
             Token::Number(n) => {
                 return Err(
@@ -188,45 +87,31 @@ fn e_expr<E>(
             }
             _ => break,
         };
-        index = t1.tokens_read;
+        index = t1.tokens;
     }
     Ok(t1)
 }
 
 // Multiplication and division
-fn t_expr<E>(
-    token_list: &[Token],
-    env: &mut E,
-) -> Result<IntermediateResult, CalcError>
+fn t_expr<E>(token_list: &[Token], env: &mut E) -> Result<IR, CalcError>
     where E: Environment
 {
     let mut f1 = f_expr(token_list, env)?;
-    let mut index = f1.tokens_read;
+    let mut index = f1.tokens;
 
     while index < token_list.len() {
         match token_list[index] {
             Token::Multiply => {
-                let f2 = f_expr(&token_list[index + 1..], env)?;
-                f1.value *= f2.value;
-                f1.tokens_read += f2.tokens_read + 1;
+                f1 = f1 * f_expr(&token_list[index + 1..], env)?;
+                f1.tokens += 1;
             }
             Token::Divide => {
-                let f2 = f_expr(&token_list[index + 1..], env)?;
-                if f2.value == 0.0 {
-                    return Err(CalcError::DivideByZero);
-                } else {
-                    f1.value /= f2.value;
-                    f1.tokens_read += f2.tokens_read + 1;
-                }
+                f1 = (f1 / f_expr(&token_list[index + 1..], env)?)?;
+                f1.tokens += 1;
             }
             Token::Modulo => {
-                let f2 = f_expr(&token_list[index + 1..], env)?;
-                if f2.value == 0.0 {
-                    return Err(CalcError::DivideByZero);
-                } else {
-                    f1.value %= f2.value;
-                    f1.tokens_read += f2.tokens_read + 1;
-                }
+                f1 = (f1 % f_expr(&token_list[index + 1..], env)?)?;
+                f1.tokens += 1;
             }
             Token::Number(n) => {
                 return Err(
@@ -235,35 +120,32 @@ fn t_expr<E>(
             }
             _ => break,
         }
-        index = f1.tokens_read;
+        index = f1.tokens;
     }
     Ok(f1)
 }
 
 // Exponentiation
-fn f_expr<E>(
-    token_list: &[Token],
-    env: &mut E,
-) -> Result<IntermediateResult, CalcError>
+fn f_expr<E>(token_list: &[Token], env: &mut E) -> Result<IR, CalcError>
     where E: Environment
 {
     let mut g1 = g_expr(token_list, env)?; // was g1
-    let mut index = g1.tokens_read;
+    let mut index = g1.tokens;
     let token_len = token_list.len();
     while index < token_len {
         match token_list[index] {
             Token::Exponent => {
                 let f = f_expr(&token_list[index + 1..], env)?;
-                g1.value = g1.value.powf(f.value);
-                g1.tokens_read += f.tokens_read + 1;
+                g1 = g1.pow(f)?;
+                g1.tokens += 1;
             }
             Token::Square => {
-                g1.value = g1.value * g1.value;
-                g1.tokens_read += 1;
+                g1 = g1.powu(2);
+                g1.tokens += 1;
             }
             Token::Cube => {
-                g1.value = g1.value * g1.value * g1.value;
-                g1.tokens_read += 1;
+                g1 = g1.powu(3);
+                g1.tokens += 1;
             }
             Token::Number(n) => {
                 return Err(
@@ -272,51 +154,47 @@ fn f_expr<E>(
             }
             _ => break,
         }
-        index = g1.tokens_read;
+        index = g1.tokens;
     }
     Ok(g1)
 }
 
 // Numbers, parenthesized expressions, and atoms
-fn g_expr<E>(
-    token_list: &[Token],
-    env: &mut E,
-) -> Result<IntermediateResult, CalcError>
+fn g_expr<E>(token_list: &[Token], env: &mut E) -> Result<IR, CalcError>
     where E: Environment
 {
     if !token_list.is_empty() {
         match token_list[0] {
-            Token::Number(n) => Ok(IntermediateResult::new(n, 1)),
+            Token::Number(n) => Ok(IR::floating(n, 1)),
             Token::Atom(ref s) => {
                 if let Some(nargs) = env.arity(s) {
                     let mut args = Vec::new();
                     let mut start = 1;
                     for _ in 0..nargs {
                         let ir = g_expr(&token_list[start..], env)?;
-                        start += ir.tokens_read;
+                        start += ir.tokens;
                         args.push(ir);
                     }
                     let res = env.resolve(s, &args);
-                    Ok(IntermediateResult::new(res?, start))
+                    Ok(IR::new(res?, start))
                 } else {
                     Err(CalcError::UnknownAtom(s.clone()))
                 }
             }
             Token::Minus => {
-                let mut ir = d_expr(&token_list[1..], env)?;
-                ir.value = -ir.value;
-                ir.tokens_read += 1;
+                let mut ir = -(d_expr(&token_list[1..], env)?);
+                ir.tokens += 1;
                 Ok(ir)
             }
             Token::OpenParen => {
-                let ir = d_expr(&token_list[1..], env)?;
-                let close_paren = ir.tokens_read + 1;
+                let mut ir = d_expr(&token_list[1..], env)?;
+                let close_paren = ir.tokens + 1;
                 if close_paren < token_list.len() {
                     match token_list[close_paren] {
-                        Token::CloseParen => Ok(IntermediateResult::new(
-                            ir.value,
-                            close_paren + 1,
-                        )),
+                        Token::CloseParen => {
+                            ir.tokens += 1;
+                            Ok(ir)
+                        }
                         _ => Err(CalcError::UnexpectedToken(
                             token_list[close_paren].to_string(),
                             ")",
@@ -347,25 +225,22 @@ impl Environment for DefaultEnvironment {
         }
     }
 
-    fn resolve(
-        &mut self,
-        atom: &str,
-        args: &[IntermediateResult],
-    ) -> Result<f64, CalcError> {
-        match atom {
-            "pi" => Ok(::std::f64::consts::PI),
-            "tau" => Ok(::std::f64::consts::PI * 2.0),
-            "log" => Ok(args[0].value.log(10.0)),
-            "sin" => Ok(args[0].value.sin()),
-            "cos" => Ok(args[0].value.cos()),
-            "tan" => Ok(args[0].value.tan()),
-            _ => Err(CalcError::UnknownAtom(atom.to_owned())),
-        }
+    fn resolve(&mut self, atom: &str, args: &[IR]) -> Result<Value, CalcError> {
+        unimplemented!()
+        // match atom {
+        //    "pi" => Ok(::std::f64::consts::PI),
+        //    "tau" => Ok(::std::f64::consts::PI * 2.0),
+        //    "log" => Ok(args[0].value.log(10.0)),
+        //    "sin" => Ok(args[0].value.sin()),
+        //    "cos" => Ok(args[0].value.cos()),
+        //    "tan" => Ok(args[0].value.tan()),
+        //    _ => Err(CalcError::UnknownAtom(atom.to_owned())),
+        // }
     }
 }
 
-pub fn parse<E>(tokens: &[Token], env: &mut E) -> Result<f64, CalcError>
+pub fn parse<E>(tokens: &[Token], env: &mut E) -> Result<Value, CalcError>
     where E: Environment
 {
-    d_expr(tokens, env).map(|answer| answer.value)
+    d_expr(tokens, env).map(|answer| answer.value())
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -80,7 +80,7 @@ fn e_expr<E>(token_list: &[Token], env: &mut E) -> Result<IR, CalcError>
                 t1 = t1 - t_expr(&token_list[index + 1..], env)?;
                 t1.tokens += 1;
             }
-            Token::Number(n) => {
+            Token::Number(ref n) => {
                 return Err(
                     CalcError::UnexpectedToken(n.to_string(), "operator"),
                 )
@@ -113,7 +113,7 @@ fn t_expr<E>(token_list: &[Token], env: &mut E) -> Result<IR, CalcError>
                 f1 = (f1 % f_expr(&token_list[index + 1..], env)?)?;
                 f1.tokens += 1;
             }
-            Token::Number(n) => {
+            Token::Number(ref n) => {
                 return Err(
                     CalcError::UnexpectedToken(n.to_string(), "operator"),
                 );
@@ -147,7 +147,7 @@ fn f_expr<E>(token_list: &[Token], env: &mut E) -> Result<IR, CalcError>
                 g1 = g1.powu(3);
                 g1.tokens += 1;
             }
-            Token::Number(n) => {
+            Token::Number(ref n) => {
                 return Err(
                     CalcError::UnexpectedToken(n.to_string(), "operator"),
                 );
@@ -165,7 +165,7 @@ fn g_expr<E>(token_list: &[Token], env: &mut E) -> Result<IR, CalcError>
 {
     if !token_list.is_empty() {
         match token_list[0] {
-            Token::Number(n) => Ok(IR::floating(n, 1)),
+            Token::Number(ref n) => Ok(IR::new(n.clone(), 1)),
             Token::Atom(ref s) => {
                 if let Some(nargs) = env.arity(s) {
                     let mut args = Vec::new();
@@ -226,21 +226,20 @@ impl Environment for DefaultEnvironment {
     }
 
     fn resolve(&mut self, atom: &str, args: &[IR]) -> Result<Value, CalcError> {
-        unimplemented!()
-        // match atom {
-        //    "pi" => Ok(::std::f64::consts::PI),
-        //    "tau" => Ok(::std::f64::consts::PI * 2.0),
-        //    "log" => Ok(args[0].value.log(10.0)),
-        //    "sin" => Ok(args[0].value.sin()),
-        //    "cos" => Ok(args[0].value.cos()),
-        //    "tan" => Ok(args[0].value.tan()),
-        //    _ => Err(CalcError::UnknownAtom(atom.to_owned())),
-        // }
+        match atom {
+            "pi" => Ok(Value::Float(::std::f64::consts::PI)),
+            "tau" => Ok(Value::Float(::std::f64::consts::PI * 2.0)),
+            "log" => Ok(Value::Float(args[0].value().as_float().log(10.0))),
+            "sin" => Ok(Value::Float(args[0].value().as_float().sin())),
+            "cos" => Ok(Value::Float(args[0].value().as_float().cos())),
+            "tan" => Ok(Value::Float(args[0].value().as_float().tan())),
+            _ => Err(CalcError::UnknownAtom(atom.to_owned())),
+        }
     }
 }
 
 pub fn parse<E>(tokens: &[Token], env: &mut E) -> Result<Value, CalcError>
     where E: Environment
 {
-    d_expr(tokens, env).map(|answer| answer.value())
+    d_expr(tokens, env).map(|answer| answer.value().clone())
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -192,7 +192,7 @@ fn g_expr<E>(token_list: &[Token], env: &mut E) -> Result<IR, CalcError>
                 if close_paren < token_list.len() {
                     match token_list[close_paren] {
                         Token::CloseParen => {
-                            ir.tokens += 1;
+                            ir.tokens = close_paren + 1;
                             Ok(ir)
                         }
                         _ => Err(CalcError::UnexpectedToken(

--- a/src/token.rs
+++ b/src/token.rs
@@ -179,7 +179,7 @@ pub fn tokenize(input: &str) -> Result<Vec<Token>, CalcError> {
 }
 
 fn digits<I>(input: &mut Peekable<I>, radix: u32) -> String
-    where I: Iterator<Item=char>
+    where I: Iterator<Item = char>
 {
     let mut number = String::new();
     while let Some(&c) = input.peek() {
@@ -193,8 +193,8 @@ fn digits<I>(input: &mut Peekable<I>, radix: u32) -> String
     number
 }
 
-fn consume_number<I>(input: &mut Peekable<I>) -> Result<Token, CalcError> 
-    where I: Iterator<Item=char>
+fn consume_number<I>(input: &mut Peekable<I>) -> Result<Token, CalcError>
+    where I: Iterator<Item = char>
 {
     match input.peek() {
         Some(&'0') => {
@@ -211,7 +211,7 @@ fn consume_number<I>(input: &mut Peekable<I>) -> Result<Token, CalcError>
             }
         }
         Some(_) => (),
-        None => return Err(CalcError::UnexpectedEndOfInput)
+        None => return Err(CalcError::UnexpectedEndOfInput),
     }
     let whole = digits(input, 10);
     if let Some(&'.') = input.peek() {
@@ -292,7 +292,7 @@ mod tests {
         let expected = vec![
             Token::Number(3735928559.0),
             Token::BitWiseOr,
-            Token::Number(12648430.0)
+            Token::Number(12648430.0),
         ];
         assert_eq!(tokenize(line), Ok(expected));
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -2,26 +2,6 @@ use std::fmt;
 use std::ops::*;
 use error::{CalcError, PartialComp};
 
-#[derive(Clone, Debug)]
-pub struct IntermediateResult {
-    pub value: f64,
-    pub tokens_read: usize,
-}
-
-impl IntermediateResult {
-    pub fn new(value: f64, tokens_read: usize) -> Self {
-        IntermediateResult { value, tokens_read }
-    }
-
-    /// Determines if the underlying value can be represented as an integer.
-    /// This is used for typechecking of sorts: we can only do bitwise
-    /// operations on integers.
-    pub fn is_whole(&self) -> bool {
-        self.value == self.value.floor()
-    }
-}
-
-
 /// Represents a canonical value that can be calculated by this library
 #[derive(Clone, Debug, PartialEq)]
 pub enum Value {
@@ -404,4 +384,25 @@ impl Shr<IR> for IR {
             tokens: self.tokens + that.tokens,
         })
     }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn float_override() {
+        let cases = vec![
+            (IR::floating(3.0, 0) + IR::dec(1, 0),
+             IR::floating(4.0, 0)),
+            (IR::hex(5, 0) - IR::floating(4.5, 0),
+             IR::floating(0.5, 0))
+        ];
+
+        for (output, expected) in cases {
+            assert_eq!(output, expected);
+        }
+    }
+
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -139,7 +139,6 @@ impl Value {
             Value::Hex(n) => Value::Hex(n.pow(i)),
         }
     }
-
 }
 
 impl fmt::Display for Value {
@@ -162,14 +161,12 @@ pub struct IR {
 }
 
 impl IR {
-
     pub fn new<T: Into<Option<usize>>>(value: Value, tokens: T) -> Self {
         IR {
             value,
             tokens: tokens.into().unwrap_or(0),
         }
     }
-
 }
 
 impl Add for Value {
@@ -316,15 +313,15 @@ mod tests {
 
     #[test]
     fn float_override() {
-        let cases =
-            vec![
-                (Value::Float(3.0) + Value::Dec(1), Value::Float(4.0)),
-                (Value::Hex(5) - Value::Float(4.5), Value::Float(0.5)),
-                (
-                    Value::Hex(24) * Value::Dec(4) * Value::Float(1.0 / 48.0),
-                    Value::Float(2.0)
-                ),
-            ];
+        let cases = vec![
+            (Value::Float(3.0) + Value::Dec(1), Value::Float(4.0)),
+            (Value::Hex(5) - Value::Float(4.5), Value::Float(0.5)),
+            (
+                Value::Hex(24) * Value::Dec(4) *
+                    Value::Float(1.0 / 48.0),
+                Value::Float(2.0)
+            ),
+        ];
 
         for (output, expected) in cases {
             assert_eq!(output, expected);
@@ -335,7 +332,10 @@ mod tests {
     fn hex_override() {
         let cases = vec![
             (Value::Hex(3) * Value::Dec(-2), Value::Hex(-6)),
-            ((Value::Hex(0x100) >> Value::Hex(0x2)).unwrap(), Value::Hex(0x40))
+            (
+                (Value::Hex(0x100) >> Value::Hex(0x2)).unwrap(),
+                Value::Hex(0x40)
+            ),
         ];
         for (output, expected) in cases {
             assert_eq!(output, expected);

--- a/src/value.rs
+++ b/src/value.rs
@@ -96,37 +96,13 @@ pub struct IR {
 }
 
 impl IR {
-    pub fn value(&self) -> &Value {
-        &self.value
+    pub fn value(self) -> Value {
+        self.value
     }
 
     pub fn new<T: Into<Option<usize>>>(value: Value, tokens: T) -> Self {
         IR {
             value,
-            tokens: tokens.into().unwrap_or(0),
-        }
-    }
-
-    /// Construct a new decimal result
-    pub fn dec<T: Into<Option<usize>>>(v: i64, tokens: T) -> Self {
-        IR {
-            value: Value::Dec(v),
-            tokens: tokens.into().unwrap_or(0),
-        }
-    }
-
-    /// Construct a new hexadecimal result
-    pub fn hex<T: Into<Option<usize>>>(v: i64, tokens: T) -> Self {
-        IR {
-            value: Value::Hex(v),
-            tokens: tokens.into().unwrap_or(0),
-        }
-    }
-
-    /// Construt a new floating point result
-    pub fn floating<T: Into<Option<usize>>>(v: f64, tokens: T) -> Self {
-        IR {
-            value: Value::Float(v),
             tokens: tokens.into().unwrap_or(0),
         }
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,0 +1,374 @@
+use std::fmt;
+use std::ops::*;
+use error::{CalcError, PartialComp};
+
+#[derive(Clone, Debug)]
+pub struct IntermediateResult {
+    pub value: f64,
+    pub tokens_read: usize,
+}
+
+impl IntermediateResult {
+    pub fn new(value: f64, tokens_read: usize) -> Self {
+        IntermediateResult { value, tokens_read }
+    }
+
+    /// Determines if the underlying value can be represented as an integer.
+    /// This is used for typechecking of sorts: we can only do bitwise
+    /// operations on integers.
+    pub fn is_whole(&self) -> bool {
+        self.value == self.value.floor()
+    }
+}
+
+
+/// Represents a canonical value that can be calculated by this library
+#[derive(Clone, Debug)]
+pub enum Value {
+    /// An integral value in decimal form. This is generally interoperable with
+    /// the `Hex` constructor, but will be overriden by the `Hex` constructor.
+    Dec(i64),
+    /// An integral value in hexadecimal form. This takes precedence over the
+    /// `Dec` constructor.
+    Hex(i64),
+    /// A floating point number
+    Float(f64),
+}
+
+impl fmt::Display for Value {
+
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Value::Dec(n) => write!(f, "{}", n),
+            Value::Hex(n) => write!(f, "{:X}", n),
+            Value::Float(n) => write!(f, "{}", n)
+        }
+    }
+
+}
+
+/// An intermediate result that can be computed by this library.
+/// - `value` represents the current computed data
+/// - `tokens` represents the number of tokens that have been consumed
+pub struct IR {
+    value: Value,
+    pub tokens: usize
+}
+
+impl IR {
+
+    /// Construct a new decimal result
+    pub fn dec<T: Into<Option<usize>>>(v: i64, tokens: T) -> Self {
+        IR {value: Value::Dec(v), tokens: tokens.into().unwrap_or(0)}
+    }
+
+    /// Construct a new hexadecimal result
+    pub fn hex<T: Into<Option<usize>>>(v: i64, tokens: T) -> Self {
+        IR {value: Value::Hex(v), tokens: tokens.into().unwrap_or(0)}
+    }
+
+    /// Construt a new floating point result
+    pub fn floating<T: Into<Option<usize>>>(v: f64, tokens: T) -> Self {
+        IR {
+            value: Value::Float(v),
+            tokens: tokens.into().unwrap_or(0),
+        }
+    }
+
+    pub fn pow(self, that: IR) -> Self {
+        let value = match (self.value, that.value) {
+            (Value::Float(n), Value::Float(m)) => Value::Float(n.powf(m)),
+            (a @ Value::Float(n), b @ Value::Hex(m)) |
+            (a @ Value::Float(n), b @ Value::Dec(m)) => {
+                if m > std::i32::MAX {
+                    return Err(CalcError::WouldOverflow(
+                        PartialComp::binary("**", a, b)
+                    ))
+                } else if m < std::i32::MIN {
+                    return Err(CalcError::WouldTruncate(
+                        PartialComp::binary("**", a, b)
+                    })
+                } else {
+                    Value::Float(n.powi(m as i32))
+                }
+            }
+            (Value::Hex(n), Value::Float(m)) |
+            (Value::Dec(n), Value::Float(m)) => {
+                Value::Float((n as f64).powf(m))
+            }
+            (Value::Hex(n), Value::Hex(m)) |
+            (Value::Dec(n), Value::Hex(m)) |
+            (Value::Hex(n), Value::Dec(m)) => {
+                if m > std::i32::MAX {
+                    return Err(CalcError::WouldOverflow(
+                        PartialComp::binary("**", a, b)
+                    ))
+                } else if m < std::i32::MIN {
+                    return Err(CalcError::WouldTruncate(
+                        PartialComp::binary("**", a, b)
+                    })
+                } else {
+                    Value::Hex(n.pow(m))
+                }
+            }
+            (Value::Dec(n), Value::Dec(m)) => Value::Dec(n + m),
+        };
+    }
+
+}
+
+impl Add for IR {
+    type Output = Self;
+
+    fn add(self, that: IR) -> Self::Output {
+        let value = match (self.value, that.value) {
+            (Value::Float(n), Value::Float(m)) => Value::Float(n + m),
+            (Value::Float(n), Value::Hex(m)) |
+            (Value::Float(n), Value::Dec(m)) => Value::Float(n + (m as f64)),
+            (Value::Hex(n), Value::Float(m)) |
+            (Value::Dec(n), Value::Float(m)) => Value::Float((n as f64) + m),
+            (Value::Hex(n), Value::Hex(m)) |
+            (Value::Dec(n), Value::Hex(m)) |
+            (Value::Hex(n), Value::Dec(m)) => Value::Hex(n + m),
+            (Value::Dec(n), Value::Dec(m)) => Value::Dec(n + m),
+        };
+        IR { value, tokens: self.tokens + that.tokens }
+    }
+
+}
+
+impl Sub for IR {
+    type Output = Self;
+
+    fn sub(self, that: IR) -> Self::Output {
+        let value = match (self.value, that.value) {
+            (Value::Float(n), Value::Float(m)) => Value::Float(n - m),
+            (Value::Float(n), Value::Hex(m)) |
+            (Value::Float(n), Value::Dec(m)) => Value::Float(n - (m as f64)),
+            (Value::Hex(n), Value::Float(m)) |
+            (Value::Dec(n), Value::Float(m)) => Value::Float((n as f64) - m),
+            (Value::Hex(n), Value::Hex(m)) |
+            (Value::Dec(n), Value::Hex(m)) |
+            (Value::Hex(n), Value::Dec(m)) => Value::Hex(n - m),
+            (Value::Dec(n), Value::Dec(m)) => Value::Dec(n - m),
+        };
+        IR { value, tokens: self.tokens + that.tokens }
+    }
+
+}
+
+impl Mul for IR {
+    type Output = Self;
+
+    fn mul(self, that: IR) -> Self::Output {
+        let value = match (self.value, that.value) {
+            (Value::Float(n), Value::Float(m)) => Value::Float(n * m),
+            (Value::Float(n), Value::Hex(m)) |
+            (Value::Float(n), Value::Dec(m)) => Value::Float(n * (m as f64)),
+            (Value::Hex(n), Value::Float(m)) |
+            (Value::Dec(n), Value::Float(m)) => Value::Float((n as f64) * m),
+            (Value::Hex(n), Value::Hex(m)) |
+            (Value::Dec(n), Value::Hex(m)) |
+            (Value::Hex(n), Value::Dec(m)) => Value::Hex(n * m),
+            (Value::Dec(n), Value::Dec(m)) => Value::Dec(n * m),
+        };
+        IR { value, tokens: self.tokens + that.tokens }
+    }
+
+}
+
+impl Div for IR {
+    type Output = Result<Self, CalcError>;
+
+    fn div(self, that: IR) -> Self::Output {
+
+        // XXX: This whole construct can be replaced with `std::num::Zero` once
+        // it is stable.
+        macro_rules! safe {
+            ($lhs:expr, $rhs:expr, $zero:expr) => {{
+                if $rhs == $zero {
+                    Err(CalcError::DivideByZero)
+                } else {
+                    Ok($lhs / $rhs)
+                }
+            }}
+        }
+
+        let value = match (self.value, that.value) {
+            (Value::Float(n), Value::Float(m)) => Value::Float(safe!(n, m, 0.0)?),
+            (Value::Float(n), Value::Hex(m)) |
+            (Value::Float(n), Value::Dec(m)) => Value::Float(safe!(n, m as f64, 0.0)?),
+            (Value::Hex(n), Value::Float(m)) |
+            (Value::Dec(n), Value::Float(m)) => Value::Float(safe!(n as f64, m, 0.0)?),
+            (Value::Hex(n), Value::Hex(m)) |
+            (Value::Dec(n), Value::Hex(m)) |
+            (Value::Hex(n), Value::Dec(m)) => Value::Hex(safe!(n, m, 0)?),
+            (Value::Dec(n), Value::Dec(m)) => Value::Dec(safe!(n, m, 0)?),
+        };
+        Ok(IR { value, tokens: self.tokens + that.tokens })
+    }
+
+}
+
+impl BitAnd for IR {
+    type Output = Result<Self, CalcError>;
+
+    fn bitand(self, that: IR) -> Self::Output {
+        let value = match (self.value, that.value) {
+            (Value::Hex(n), Value::Hex(m)) |
+            (Value::Hex(n), Value::Dec(m)) |
+            (Value::Dec(n), Value::Hex(m)) => Value::Hex(n & m),
+            (Value::Dec(n), Value::Dec(m)) => Value::Dec(n & m),
+            (v1 @ Value::Float(_), v2 @ _) |
+            (v1 @ _, v2 @ Value::Float(_)) => {
+                return Err(CalcError::BadTypes(
+                    PartialComp::binary("&", v1, v2)
+                ))
+            }
+        };
+        Ok(IR { value, tokens: self.tokens + that.tokens })
+    }
+}
+
+impl BitOr for IR {
+    type Output = Result<Self, CalcError>;
+
+    fn bitor(self, that: IR) -> Self::Output {
+        let value = match (self.value, that.value) {
+            (Value::Hex(n), Value::Hex(m)) |
+            (Value::Hex(n), Value::Dec(m)) |
+            (Value::Dec(n), Value::Hex(m)) => Value::Hex(n | m),
+            (Value::Dec(n), Value::Dec(m)) => Value::Dec(n | m),
+            (v1 @ Value::Float(_), v2 @ _) |
+            (v1 @ _, v2 @ Value::Float(_)) => {
+                return Err(CalcError::BadTypes(
+                    PartialComp::binary("|", v1, v2)
+                ))
+            }
+        };
+        Ok(IR { value, tokens: self.tokens + that.tokens })
+    }
+}
+
+impl BitXor for IR {
+    type Output = Result<Self, CalcError>;
+
+    fn bitxor(self, that: IR) -> Self::Output {
+        let value = match (self.value, that.value) {
+            (Value::Hex(n), Value::Hex(m)) |
+            (Value::Hex(n), Value::Dec(m)) |
+            (Value::Dec(n), Value::Hex(m)) => Value::Hex(n ^ m),
+            (Value::Dec(n), Value::Dec(m)) => Value::Dec(n ^ m),
+            (v1 @ Value::Float(_), v2 @ _) |
+            (v1 @ _, v2 @ Value::Float(_)) => {
+                return Err(CalcError::BadTypes(
+                    PartialComp::binary("^", v1, v2)
+                ))
+            }
+        };
+        Ok(IR { value, tokens: self.tokens + that.tokens })
+    }
+}
+
+impl Neg for IR {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        let value = match self.value {
+            Value::Hex(n) => Value::Hex(-n),
+            Value::Dec(n) => Value::Dec(-n),
+            Value::Float(f) => Value::Float(-f),
+        };
+        IR { value, tokens: self.tokens }
+    }
+}
+
+impl Not for IR {
+    type Output = Result<Self, CalcError>;
+
+    fn not(self) -> Self::Output {
+        let value = match self.value {
+            Value::Hex(n) => Value::Hex(!n),
+            Value::Dec(n) => Value::Dec(!n),
+            Value::Float(f) => {
+                return Err(CalcError::BadTypes(PartialComp::unary("~", f)))
+            }
+        };
+        Ok(IR { value, tokens: self.tokens })
+    }
+}
+
+
+impl Rem for IR {
+    type Output = Result<Self, CalcError>;
+
+    fn rem(self, that: IR) -> Self::Output {
+
+        // XXX: This whole construct can be replaced with `std::num::Zero` once
+        // it is stable.
+        macro_rules! safe {
+            ($lhs:expr, $rhs:expr, $zero:expr) => {{
+                if $rhs == $zero {
+                    Err(CalcError::DivideByZero)
+                } else {
+                    Ok($lhs % $rhs)
+                }
+            }}
+        }
+
+        let value = match (self.value, that.value) {
+            (Value::Float(n), Value::Float(m)) => Value::Float(safe!(n, m, 0.0)?),
+            (Value::Float(n), Value::Hex(m)) |
+            (Value::Float(n), Value::Dec(m)) => Value::Float(safe!(n, m as f64, 0.0)?),
+            (Value::Hex(n), Value::Float(m)) |
+            (Value::Dec(n), Value::Float(m)) => Value::Float(safe!(n as f64, m, 0.0)?),
+            (Value::Hex(n), Value::Hex(m)) |
+            (Value::Dec(n), Value::Hex(m)) |
+            (Value::Hex(n), Value::Dec(m)) => Value::Hex(safe!(n, m, 0)?),
+            (Value::Dec(n), Value::Dec(m)) => Value::Dec(safe!(n, m, 0)?),
+        };
+        Ok(IR { value, tokens: self.tokens + that.tokens })
+    }
+
+}
+
+impl Shl<IR> for IR {
+    type Output = Result<Self, CalcError>;
+
+    fn shl(self, that: IR) -> Self::Output {
+        let value = match (self.value, that.value) {
+            (Value::Hex(n), Value::Hex(m)) |
+            (Value::Hex(n), Value::Dec(m)) |
+            (Value::Dec(n), Value::Hex(m)) => Value::Hex(n << m),
+            (Value::Dec(n), Value::Dec(m)) => Value::Dec(n << m),
+            (v1 @ Value::Float(_), v2 @ _) |
+            (v1 @ _, v2 @ Value::Float(_)) => {
+                return Err(CalcError::BadTypes(
+                    PartialComp::binary("<<", v1, v2)
+                ))
+            }
+        };
+        Ok(IR { value, tokens: self.tokens + that.tokens })
+    }
+}
+
+
+impl Shr<IR> for IR {
+    type Output = Result<Self, CalcError>;
+
+    fn shr(self, that: IR) -> Self::Output {
+        let value = match (self.value, that.value) {
+            (Value::Hex(n), Value::Hex(m)) |
+            (Value::Hex(n), Value::Dec(m)) |
+            (Value::Dec(n), Value::Hex(m)) => Value::Hex(n >> m),
+            (Value::Dec(n), Value::Dec(m)) => Value::Dec(n >> m),
+            (v1 @ Value::Float(_), v2 @ _) |
+            (v1 @ _, v2 @ Value::Float(_)) => {
+                return Err(CalcError::BadTypes(
+                    PartialComp::binary(">>", v1, v2)
+                ))
+            }
+        };
+        Ok(IR { value, tokens: self.tokens + that.tokens })
+    }
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -100,7 +100,7 @@ impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Value::Dec(n) => write!(f, "{}", n),
-            Value::Hex(n) => write!(f, "{:X}", n),
+            Value::Hex(n) => write!(f, "0x{:X}", n),
             Value::Float(n) => write!(f, "{}", n),
         }
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -397,7 +397,9 @@ mod tests {
             (IR::floating(3.0, 0) + IR::dec(1, 0),
              IR::floating(4.0, 0)),
             (IR::hex(5, 0) - IR::floating(4.5, 0),
-             IR::floating(0.5, 0))
+             IR::floating(0.5, 0)),
+            (IR::hex(24, 0) * IR::dec(4, 0) * IR::floating(1.0 / 48.0, 0),
+             IR::floating(2.0, 0))
         ];
 
         for (output, expected) in cases {

--- a/src/value.rs
+++ b/src/value.rs
@@ -393,14 +393,15 @@ mod tests {
 
     #[test]
     fn float_override() {
-        let cases = vec![
-            (IR::floating(3.0, 0) + IR::dec(1, 0),
-             IR::floating(4.0, 0)),
-            (IR::hex(5, 0) - IR::floating(4.5, 0),
-             IR::floating(0.5, 0)),
-            (IR::hex(24, 0) * IR::dec(4, 0) * IR::floating(1.0 / 48.0, 0),
-             IR::floating(2.0, 0))
-        ];
+        let cases =
+            vec![
+                (IR::floating(3.0, 0) + IR::dec(1, 0), IR::floating(4.0, 0)),
+                (IR::hex(5, 0) - IR::floating(4.5, 0), IR::floating(0.5, 0)),
+                (
+                    IR::hex(24, 0) * IR::dec(4, 0) * IR::floating(1.0 / 48.0, 0),
+                    IR::floating(2.0, 0)
+                ),
+            ];
 
         for (output, expected) in cases {
             assert_eq!(output, expected);


### PR DESCRIPTION
- Numbers are now typed according to their format / internal representation
- The type that stores numbers, `Value`, now has operator overloads that performs the correct casting / error handling
- Division will not preserve type: for example, `4 / 3` will be `1.3333...` not `1`

Closes #10.