### PR TITLE
Implement Polish Notation Support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,15 +14,64 @@ mod value;
 pub use value::Value;
 pub use error::CalcError;
 
+/// Evalulates a regular mathematical expression.
 pub fn eval(input: &str) -> Result<Value, CalcError> {
     let mut env = parse::DefaultEnvironment;
     token::tokenize(input).and_then(|x| parse::parse(&x, &mut env))
 }
 
+/// Evalulates a regular mathematical expression, with extra environment
+/// variables.
 pub fn eval_with_env<E>(input: &str, env: &mut E) -> Result<Value, CalcError>
     where E: parse::Environment
 {
     token::tokenize(input).and_then(|x| parse::parse(&x, env))
+}
+
+/// Evalulates mathematical expressions that are written in Polish Notation.
+///
+/// Polish Notation defines that a string of operators are given at the
+/// beginning of the
+/// expression, as prefixes, and are followed by a string of numbers to apply
+/// each operation
+/// to. Polish Notation enables writing mathematical expressions that don't
+/// require grouping
+/// via parenthesis. It's also referred to as Prefix Notation, or Normal Polish
+/// Notation (NPN).
+///
+/// # Examples
+///
+/// - `+ * 3 4 5` is equivalent to `3 * 4 + 5`
+/// - `+ / * 5 3 2 * + 1 3 5` is equivalent to `((5 * 3) / 2) + ((1 + 3) * 5)`
+pub fn eval_polish(input: &str) -> Result<Value, CalcError> {
+    let mut env = parse::DefaultEnvironment;
+    token::tokenize_polish(input).and_then(|x| parse::parse(&x, &mut env))
+}
+
+/// Evalulates mathematical expressions that are written in Polish Notation,
+/// with extra
+/// environment variables.
+///
+/// Polish Notation defines that a string of operators are given at the
+/// beginning of the
+/// expression, as prefixes, and are followed by a string of numbers to apply
+/// each operation
+/// to. Polish Notation enables writing mathematical expressions that don't
+/// require grouping
+/// via parenthesis. It's also referred to as prefix notation, or Normal Polish
+/// Notation (NPN).
+///
+/// # Examples
+///
+/// - `+ * 3 4 5` is equivalent to `3 * 4 + 5`
+/// - `+ / * 5 3 2 * + 1 3 5` is equivalent to `((5 * 3) / 2) + ((1 + 3) * 5)`
+pub fn eval_polish_with_env<E>(
+    input: &str,
+    env: &mut E,
+) -> Result<Value, CalcError>
+    where E: parse::Environment
+{
+    token::tokenize_polish(input).and_then(|x| parse::parse(&x, env))
 }
 
 #[cfg(test)]
@@ -45,6 +94,23 @@ mod tests {
         ];
         for (input, expected) in cases {
             assert_eq!(eval(input), Ok(expected));
+        }
+    }
+
+    #[test]
+    fn polish() {
+        let cases = vec![
+            (" + 1 1", Value::Dec(2)),
+            (" - * 4 7 14", Value::Dec(14)),
+            (" << 2 16", Value::Dec(131072)),
+            (" / % * 4 18 17 3", Value::Float(4.0 / 3.0)),
+            ("* + 1 3 5", Value::Dec(20)),
+            ("+ / * 5 3 2 * + 1 3 5", Value::Float(27.5)),
+            ("^ ^ ^ ^ ^ 4 3 2 3 4 2", Value::Dec(0)),
+            ("<< 3 >> 4 2", Value::Dec(6)),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(eval_polish(input), Ok(expected));
         }
     }
 


### PR DESCRIPTION
Implements support for polish notation in the library and binary, so calc will now support both prefix and infix modes. It works by temporarily storing operators and values into two separate vectors, and then collecting them together into infix order so that it can take advantage of the existing token parser. Parenthesis are also added to disrupt the order of operations rules that infix math has to abide by, but does not apply to prefix math. The binary now also checks for either a `-p` or `--polish` flag, then choosing the corresponding evaluator accordingly.

This will be much more useful in Ion once support for the **<** /**>**/**<=**/**>=**/**==**/**!=** operators are added, which would enable for prefix-based conditional checks.

Closes #4