### PR TITLE
add conversion from CalcError to String

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -114,3 +114,9 @@ impl From<ParseIntError> for CalcError {
         CalcError::InvalidNumber(data.description().into())
     }
 }
+
+impl From<CalcError> for String {
+    fn from(data: CalcError) -> String {
+        format!("{}", data)
+    }
+}


### PR DESCRIPTION
Implement From<CalcError> for String 
Allowing for error messages to be generated from CalcErrors.