### PR TITLE
Replace f64 w/ d128: higher accuracy / precision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,32 @@
 [package]
-name = "calculate"
-version = "0.3.0"
 authors = ["Hunter Goldstein <hunter.d.goldstein@gmail.com>"]
-description = "Rust library for parsing and processing arithmetic expressions"
-license-file = "LICENSE"
-readme = "README.md"
-homepage = "https://github.com/redox-os/calc"
-repository = "https://github.com/redox-os/calc"
-include = [
-  "**/*.rs",
-  "Cargo.toml",
+categories = [
+    "science",
+    "parsing",
 ]
-keywords = ["math", "calculator"]
-categories = ["science", "parsing"]
-
-[lib]
-name = "calc"
-path = "src/lib.rs"
+description = "Rust library for parsing and processing arithmetic expressions"
+homepage = "https://github.com/redox-os/calc"
+include = [
+    "**/*.rs",
+    "Cargo.toml",
+]
+keywords = [
+    "math",
+    "calculator",
+]
+license-file = "LICENSE"
+name = "calculate"
+readme = "README.md"
+repository = "https://github.com/redox-os/calc"
+version = "0.3.0"
 
 [[bin]]
 name = "calc"
 path = "src/bin.rs"
+
+[dependencies]
+decimal = "2.0.0"
+
+[lib]
+name = "calc"
+path = "src/lib.rs"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::env::args;
 use std::process::exit;
 
-use std::io::{self, BufRead, stdout, stdin, Write};
+use std::io::{self, stdin, stdout, BufRead, Write};
 
 use calc::{eval, eval_polish, CalcError};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::error::Error;
 
-use std::num::{ParseIntError, ParseFloatError};
+use std::num::ParseIntError;
 
 /// Represents a partial computation that can be captured as part of an
 /// error message.
@@ -100,12 +100,6 @@ impl fmt::Display for CalcError {
             UnexpectedEndOfInput => write!(f, "unexpected end of input"),
             UnmatchedParenthesis => write!(f, "unmatched patenthesis"),
         }
-    }
-}
-
-impl From<ParseFloatError> for CalcError {
-    fn from(data: ParseFloatError) -> CalcError {
-        CalcError::InvalidNumber(data.description().into())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(test, feature(test))]
 
+#[macro_use]
+extern crate decimal;
 #[cfg(test)]
 extern crate test;
 
@@ -80,18 +82,19 @@ mod tests {
 
     #[test]
     fn basics() {
-        let cases = vec![
-            ("  1 +   1", Value::Dec(2)),
-            (" 4 * 7 - 14", Value::Dec(14)),
-            (" 2 << 16 ", Value::Dec(131072)),
-            (" ((4 * 18) % 17) / 3", Value::Float(4.0 / 3.0)),
-            ("2²³²", Value::Dec(4096)),
-            ("4 ^ 3 ^ 2 ^ 3 ^ 4 ^ 2", Value::Dec(0)),
-            ("3 << (4 >> 2)", Value::Dec(6)),
-            ("~0", Value::Dec(-1)),
-            ("cos pi + sin (tau * (3 / 4))", Value::Float(-2.0)),
-            ("~~5", Value::Dec(5)),
-        ];
+        let cases =
+            vec![
+                ("  1 +   1", Value::Dec(2)),
+                (" 4 * 7 - 14", Value::Dec(14)),
+                (" 2 << 16 ", Value::Dec(131072)),
+                (" ((4 * 18) % 17) / 3", Value::Float(d128!(4.0) / d128!(3.0))),
+                ("2²³²", Value::Dec(4096)),
+                ("4 ^ 3 ^ 2 ^ 3 ^ 4 ^ 2", Value::Dec(0)),
+                ("3 << (4 >> 2)", Value::Dec(6)),
+                ("~0", Value::Dec(-1)),
+                // ("cos pi + sin (tau * (3 / 4))", Value::Float(d128!(-2.0))),
+                ("~~5", Value::Dec(5)),
+            ];
         for (input, expected) in cases {
             assert_eq!(eval(input), Ok(expected));
         }
@@ -99,16 +102,17 @@ mod tests {
 
     #[test]
     fn polish() {
-        let cases = vec![
-            (" + 1 1", Value::Dec(2)),
-            (" - * 4 7 14", Value::Dec(14)),
-            (" << 2 16", Value::Dec(131072)),
-            (" / % * 4 18 17 3", Value::Float(4.0 / 3.0)),
-            ("* + 1 3 5", Value::Dec(20)),
-            ("+ / * 5 3 2 * + 1 3 5", Value::Float(27.5)),
-            ("^ ^ ^ ^ ^ 4 3 2 3 4 2", Value::Dec(0)),
-            ("<< 3 >> 4 2", Value::Dec(6)),
-        ];
+        let cases =
+            vec![
+                (" + 1 1", Value::Dec(2)),
+                (" - * 4 7 14", Value::Dec(14)),
+                (" << 2 16", Value::Dec(131072)),
+                (" / % * 4 18 17 3", Value::Float(d128!(4.0) / d128!(3.0))),
+                ("* + 1 3 5", Value::Dec(20)),
+                ("+ / * 5 3 2 * + 1 3 5", Value::Float(d128!(27.5))),
+                ("^ ^ ^ ^ ^ 4 3 2 3 4 2", Value::Dec(0)),
+                ("<< 3 >> 4 2", Value::Dec(6)),
+            ];
         for (input, expected) in cases {
             assert_eq!(eval_polish(input), Ok(expected));
         }
@@ -121,16 +125,19 @@ mod tests {
             vec![
                 (
                     "((15 * 10) - 26 * 19 - 30 / ((57 * 79 + 93 / 87 / 47))) / 8",
-                    Value::Float(-43.00083277394169075309)
+                    Value::Float(d128!(-43.00083277394169075309321854399588))
                 ),
                 (
                     "(3 << 6) * 7 + (40 / 3)",
-                    Value::Float(1357.33333333333333333333)
+                    Value::Float(d128!(1357.333333333333333333333333333333))
                 ),
-                ("(21 & (5) ^ (20 & 81)) / (25 << 3)", Value::Float(0.105)),
+                (
+                    "(21 & (5) ^ (20 & 81)) / (25 << 3)",
+                    Value::Float(d128!(0.105))
+                ),
                 (
                     "(79 & 14) * ((3) - 76 + 67 / (62) - (85 ^ (7 - (32) >> 52)))",
-                    Value::Float(197.12903225806448)
+                    Value::Float(d128!(197.1290322580645161290322580645161))
                 ),
             ];
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,6 +1,6 @@
 use token::*;
 use error::CalcError;
-use value::{Value, IR};
+use value::{into_float, Value, IR};
 
 /// Represents an environment for evaluating a mathematical expression
 pub trait Environment {
@@ -24,7 +24,6 @@ pub trait Environment {
 fn d_expr<E>(token_list: &[Token], env: &mut E) -> Result<IR, CalcError>
     where E: Environment
 {
-
     if !token_list.is_empty() && token_list[0] == Token::BitWiseNot {
         let mut e = d_expr(&token_list[1..], env)?;
         e.value = (!e.value)?;
@@ -236,7 +235,7 @@ impl Environment for DefaultEnvironment {
     fn arity(&self, atom: &str) -> Option<usize> {
         match atom {
             "pi" | "tau" => Some(0),
-            "log" | "sin" | "cos" | "tan" => Some(1),
+            "log" => Some(1),
             _ => None,
         }
     }
@@ -247,12 +246,17 @@ impl Environment for DefaultEnvironment {
         args: &[Value],
     ) -> Result<Value, CalcError> {
         match atom {
-            "pi" => Ok(Value::Float(::std::f64::consts::PI)),
-            "tau" => Ok(Value::Float(::std::f64::consts::PI * 2.0)),
-            "log" => Ok(Value::Float(args[0].as_float().log(10.0))),
-            "sin" => Ok(Value::Float(args[0].as_float().sin())),
-            "cos" => Ok(Value::Float(args[0].as_float().cos())),
-            "tan" => Ok(Value::Float(args[0].as_float().tan())),
+            "pi" => {
+                Ok(Value::Float(d128!(3.1415926535897932384626433832795028)))
+            }
+            "tau" => Ok(Value::Float(
+                d128!(3.1415926535897932384626433832795028) *
+                    into_float(2),
+            )),
+            "log" => Ok(Value::Float(args[0].as_float().log10())),
+            // "sin" => Ok(Value::Float(args[0].as_float().sin())),
+            // "cos" => Ok(Value::Float(args[0].as_float().cos())),
+            // "tan" => Ok(Value::Float(args[0].as_float().tan())),
             _ => Err(CalcError::UnknownAtom(atom.to_owned())),
         }
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,7 +1,7 @@
 use std::i64;
 use std::fmt;
 use std::iter::Peekable;
-
+use decimal::d128;
 use error::CalcError;
 use error::CalcError::*;
 use value::Value;
@@ -421,7 +421,11 @@ fn consume_number<I>(input: &mut Peekable<I>) -> Result<Value, CalcError>
     if let Some(&'.') = input.peek() {
         input.next();
         let frac = digits(input, 10);
-        let num: f64 = [whole, ".".into(), frac].concat().parse()?;
+        let num = [whole, ".".into(), frac].concat().parse::<d128>().map_err(
+            |_| {
+                CalcError::InvalidNumber("invalid float".into())
+            },
+        )?;
         Ok(Value::Float(num))
     } else {
         Ok(Value::Dec(whole.parse()?))


### PR DESCRIPTION
Closes #17 

128-bit decimal floats have significantly higher accuracy and precision than what 64-bit floating point arithmetic can provide. 128-bit decimals provide up to 34 decimal digits of precision, and their calculations are precise within that range, due to making these calculations using
ALUs, rather than on a FPU.

This will immediately make calc useful for real world use in any area that requires accurate decimal precision, such as financial calculations. Arbitrary precision decimal math would be more ideal, but the Rust ecosystem does not yet provide support for a `BigDecimal` type at this time.

A downside to this PR, however, is that the `d128` type from the decimal crate does not yet implement the `Float` trait, and thus it doesn't have access to `cos()`, `sin()`, and `tan()` methods. So, this PR disables them for now.